### PR TITLE
Serve unsaved buffer snapshots instead of forcing saves on type

### DIFF
--- a/LiveServerPlus.py
+++ b/LiveServerPlus.py
@@ -20,6 +20,7 @@ if VENDOR_PATH not in sys.path:
 # Now the imports will work
 from .liveserverplus_lib.logging import info, error
 from .liveserverplus_lib.path_utils import normalize_url_path, join_base_and_path
+from .liveserverplus_lib.buffer_cache import BufferCache
 from .ServerManager import ServerManager
 
 from .liveserverplus_lib.qr_utils import (get_server_urls, generate_qr_code_base64, HAS_QR_SUPPORT, get_local_ip)
@@ -533,10 +534,16 @@ class LiveServerPlusListener(sublime_plugin.EventListener):
     def on_post_save_async(self, view):
         manager = ServerManager.getInstance()
         server = manager.getServer()
+
+        # Saved file is now authoritative on disk; drop any cached buffer
+        # snapshot so subsequent requests read the post-hooks contents.
+        file_path = view.file_name()
+        if file_path:
+            BufferCache.getInstance().evict(file_path)
+
         if not server or not server.settings.liveReload:
             return
 
-        file_path = view.file_name()
         if not self._should_trigger(manager, server, file_path):
             return
 
@@ -564,34 +571,36 @@ class LiveServerPlusListener(sublime_plugin.EventListener):
         _last_modified[file_path] = timestamp
         mode = "instant" if delay_ms <= 0 else "debounced"
 
-        def attempt_save(v=view, path=file_path, stamp=timestamp, retries=0):
+        def attempt_reload(v=view, path=file_path, stamp=timestamp):
             if _last_modified.get(path) != stamp:
                 return
 
             if v.window() is None:
                 return
 
-            # Avoid closing the auto-complete dropdown mid-selection (notably disruptive on Windows).
-            # Retry up to ~3 seconds (25 retries * 120ms) then give up to avoid infinite loops.
-            if v.is_auto_complete_visible():
-                if retries < 25:
-                    sublime.set_timeout(lambda: attempt_save(v, path, stamp, retries + 1), 120)
+            # Snapshot the dirty buffer so the dev server can serve the
+            # in-progress edit without invoking Sublime's save pipeline
+            # (which would run on-save hooks like trim_trailing_white_space).
+            try:
+                content = v.substr(sublime.Region(0, v.size()))
+            except Exception as exc:
+                error(f"Live reload buffer snapshot failed for {path}: {exc}")
                 return
 
-            if not v.is_dirty():
-                return
+            BufferCache.getInstance().put(path, content)
 
             info(f"Live reload ({mode}): {path}")
-            v.run_command('save')
+            manager.onFileChange(path)
 
-        sublime.set_timeout(lambda: attempt_save(view, file_path, timestamp), max(0, int(delay_ms)))
+        sublime.set_timeout(lambda: attempt_reload(view, file_path, timestamp), max(0, int(delay_ms)))
 
     def on_close(self, view):
-        """Clean up debounce state when a view closes."""
+        """Clean up debounce state and cached buffer when a view closes."""
         self._last_change_count.pop(view.id(), None)
         file_path = view.file_name()
         if file_path:
             _last_modified.pop(file_path, None)
+            BufferCache.getInstance().evict(file_path)
 
 class LiveServerContextProvider(sublime_plugin.EventListener):
     """Provides context for key bindings"""
@@ -833,6 +842,7 @@ def plugin_unloaded():
         # Clear singleton instance to prevent memory leaks
         ServerManager._instance = None
         _SCROLL_SYNC_LISTENERS.clear()
+        BufferCache.getInstance().clear()
         info("Plugin unloaded successfully")
     except Exception as e:
         error(f"Error during plugin unload: {e}")

--- a/LiveServerPlus.py
+++ b/LiveServerPlus.py
@@ -26,7 +26,6 @@ from .ServerManager import ServerManager
 from .liveserverplus_lib.qr_utils import (get_server_urls, generate_qr_code_base64, HAS_QR_SUPPORT, get_local_ip)
 
 
-_last_modified = {}
 _SCROLL_SYNC_LISTENERS = {}
 
 
@@ -566,40 +565,27 @@ class LiveServerPlusListener(sublime_plugin.EventListener):
             return
         self._last_change_count[view.id()] = change_count
 
-        delay_ms = server.settings.waitTimeMs
-        timestamp = time.time()
-        _last_modified[file_path] = timestamp
-        mode = "instant" if delay_ms <= 0 else "debounced"
+        # Snapshot the dirty buffer synchronously so the cache always
+        # reflects the latest keystroke. The WebSocket layer does its own
+        # debounce/coalescing of the broadcast itself; stacking a second
+        # debounce here used to race the broadcast and drop final updates
+        # (e.g. hit backspace twice rapidly and lose the second one).
+        try:
+            content = view.substr(sublime.Region(0, view.size()))
+        except Exception as exc:
+            error(f"Live reload buffer snapshot failed for {file_path}: {exc}")
+            return
 
-        def attempt_reload(v=view, path=file_path, stamp=timestamp):
-            if _last_modified.get(path) != stamp:
-                return
+        BufferCache.getInstance().put(file_path, content)
 
-            if v.window() is None:
-                return
-
-            # Snapshot the dirty buffer so the dev server can serve the
-            # in-progress edit without invoking Sublime's save pipeline
-            # (which would run on-save hooks like trim_trailing_white_space).
-            try:
-                content = v.substr(sublime.Region(0, v.size()))
-            except Exception as exc:
-                error(f"Live reload buffer snapshot failed for {path}: {exc}")
-                return
-
-            BufferCache.getInstance().put(path, content)
-
-            info(f"Live reload ({mode}): {path}")
-            manager.onFileChange(path)
-
-        sublime.set_timeout(lambda: attempt_reload(view, file_path, timestamp), max(0, int(delay_ms)))
+        info(f"Live reload: {file_path}")
+        manager.onFileChange(file_path)
 
     def on_close(self, view):
         """Clean up debounce state and cached buffer when a view closes."""
         self._last_change_count.pop(view.id(), None)
         file_path = view.file_name()
         if file_path:
-            _last_modified.pop(file_path, None)
             BufferCache.getInstance().evict(file_path)
 
 class LiveServerContextProvider(sublime_plugin.EventListener):

--- a/LiveServerPlus.sublime-settings
+++ b/LiveServerPlus.sublime-settings
@@ -41,7 +41,8 @@
     "fullReload": false,
 
     // Debounce delay (ms) for reload events.
-    // Note: when "liveReload" is true, this also controls the auto-save debounce used to trigger reloads.
+    // When "liveReload" is true, this debounces the reload broadcast triggered by buffer modifications.
+    // The dev server serves the in-progress buffer snapshot, so your file is not saved until you save it.
     "wait": 100,
 
     // Glob patterns ignored by both Watchdog and Sublime live reload.

--- a/liveserverplus_lib/buffer_cache.py
+++ b/liveserverplus_lib/buffer_cache.py
@@ -1,0 +1,72 @@
+# liveserverplus_lib/buffer_cache.py
+"""Thread-safe cache of unsaved Sublime buffer content.
+
+Populated from Sublime's modify event listener and consumed by HTTP worker
+threads when serving files. Lets the dev server preview in-progress edits
+without forcing a save (which would trigger on-save hooks like
+trim_trailing_white_space_on_save, format-on-save, ensure_newline_at_eof, etc).
+"""
+import os
+import threading
+
+
+class BufferCache:
+    """Singleton {abs_path -> bytes} cache of dirty buffer snapshots."""
+
+    _instance = None
+    _instance_lock = threading.Lock()
+
+    @classmethod
+    def getInstance(cls):
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+        return cls._instance
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._cache = {}
+
+    @staticmethod
+    def _normalize(path):
+        if not path:
+            return None
+        try:
+            # realpath resolves symlinks so cache keys agree with paths the
+            # file_server produces via validate_and_secure_path (which calls
+            # pathlib's resolve()). normcase handles platform case-insensitivity.
+            return os.path.normcase(os.path.realpath(path))
+        except Exception:
+            try:
+                return os.path.normcase(os.path.normpath(path))
+            except Exception:
+                return path
+
+    def put(self, path, content):
+        key = self._normalize(path)
+        if not key:
+            return
+        if isinstance(content, str):
+            content = content.encode('utf-8', errors='replace')
+        elif not isinstance(content, (bytes, bytearray)):
+            return
+        with self._lock:
+            self._cache[key] = bytes(content)
+
+    def get(self, path):
+        key = self._normalize(path)
+        if not key:
+            return None
+        with self._lock:
+            return self._cache.get(key)
+
+    def evict(self, path):
+        key = self._normalize(path)
+        if not key:
+            return
+        with self._lock:
+            self._cache.pop(key, None)
+
+    def clear(self):
+        with self._lock:
+            self._cache.clear()

--- a/liveserverplus_lib/file_server.py
+++ b/liveserverplus_lib/file_server.py
@@ -10,6 +10,7 @@ from .http_utils import (HTTPResponse, create_file_response, create_error_respon
 from .logging import info, error
 from .constants import STREAMING_THRESHOLD, LARGE_FILE_THRESHOLD
 from .markdown_renderer import MarkdownRenderer, guess_markdown_title
+from .buffer_cache import BufferCache
 
 
 class FileServer:
@@ -72,19 +73,27 @@ class FileServer:
         if getattr(self.settings, 'logging', False):
             info(f"Rendering Markdown preview: {file_path}")
 
-        try:
-            with open(file_path, 'r', encoding='utf-8') as handle:
-                markdown_source = handle.read()
-        except UnicodeDecodeError:
+        cached = BufferCache.getInstance().get(file_path)
+        if cached is not None:
             try:
-                with open(file_path, 'r', encoding='utf-8', errors='replace') as handle:
+                markdown_source = cached.decode('utf-8', errors='replace')
+            except Exception as exc:
+                error(f"Error decoding cached markdown buffer for {file_path}: {exc}")
+                return False
+        else:
+            try:
+                with open(file_path, 'r', encoding='utf-8') as handle:
                     markdown_source = handle.read()
+            except UnicodeDecodeError:
+                try:
+                    with open(file_path, 'r', encoding='utf-8', errors='replace') as handle:
+                        markdown_source = handle.read()
+                except OSError as exc:
+                    error(f"Error reading markdown file {file_path}: {exc}")
+                    return False
             except OSError as exc:
                 error(f"Error reading markdown file {file_path}: {exc}")
                 return False
-        except OSError as exc:
-            error(f"Error reading markdown file {file_path}: {exc}")
-            return False
 
         title = guess_markdown_title(file_path, markdown_source)
 
@@ -122,19 +131,26 @@ class FileServer:
 
         if file_ext == '.md' and self.settings.renderMarkdownPreview:
             return self._serveMarkdown(conn, full_path)
-            
+
         # Check if file is allowed using centralized function with optimized set
         is_allowed = isFileAllowed(full_path, self.settings.allowedFileTypesSet)
-        
+
+        mime_type = get_mime_type(full_path)
+
+        # If a Sublime view holds an unsaved edit for this path, serve that
+        # snapshot instead of the on-disk bytes so live reload reflects
+        # in-progress typing without forcing a save.
+        cached = BufferCache.getInstance().get(full_path)
+        if cached is not None and is_allowed:
+            return self._sendFileContents(conn, full_path, mime_type, override_bytes=cached)
+
         # Get file size for streaming decision
         try:
             file_size = os.path.getsize(full_path)
             should_stream = file_size > STREAMING_THRESHOLD
         except OSError:
             return False
-            
-        mime_type = get_mime_type(full_path)
-        
+
         # Handle different serving methods
         if is_allowed:
             if should_stream and not full_path.lower().endswith(('.html', '.htm')):
@@ -162,18 +178,27 @@ class FileServer:
             error(f"Error reading file {file_path}: {e}")
             return None
             
-    def _sendFileContents(self, conn, file_path, mime_type):
-        """Send file contents with optional WebSocket injection"""
-        # Check file size first to avoid loading large files
-        try:
-            file_size = os.path.getsize(file_path)
-            # Large files should be streamed, not loaded into memory
-            if file_size > LARGE_FILE_THRESHOLD and not file_path.lower().endswith(('.html', '.htm')):
-                return self._streamFile(conn, file_path, mime_type)
-        except OSError:
-            pass
-        
-        content = self._readFileFromDisk(file_path)
+    def _sendFileContents(self, conn, file_path, mime_type, override_bytes=None):
+        """Send file contents with optional WebSocket injection.
+
+        ``override_bytes`` lets callers bypass the disk read (used when a
+        dirty Sublime buffer snapshot should be served instead of the
+        on-disk contents).
+        """
+        if override_bytes is None:
+            # Check file size first to avoid loading large files
+            try:
+                file_size = os.path.getsize(file_path)
+                # Large files should be streamed, not loaded into memory
+                if file_size > LARGE_FILE_THRESHOLD and not file_path.lower().endswith(('.html', '.htm')):
+                    return self._streamFile(conn, file_path, mime_type)
+            except OSError:
+                pass
+
+            content = self._readFileFromDisk(file_path)
+        else:
+            content = override_bytes
+
         if content is None:
             return False
             

--- a/liveserverplus_lib/file_server.py
+++ b/liveserverplus_lib/file_server.py
@@ -20,6 +20,16 @@ class FileServer:
         self.settings = settings
         self.websocket_injector = None  # Will be set by RequestHandler
         self.markdown_renderer = MarkdownRenderer()
+
+    def _cachedBufferFor(self, file_path):
+        """Return cached buffer bytes for ``file_path`` only when live
+        reload is active. The cache is populated by the Sublime modify
+        listener which runs only in that mode, so consulting it
+        otherwise risks serving stale snapshots from a previous session.
+        """
+        if not getattr(self.settings, 'liveReload', False):
+            return None
+        return BufferCache.getInstance().get(file_path)
         
     def serveFile(self, conn, path, folders):
         """
@@ -73,7 +83,7 @@ class FileServer:
         if getattr(self.settings, 'logging', False):
             info(f"Rendering Markdown preview: {file_path}")
 
-        cached = BufferCache.getInstance().get(file_path)
+        cached = self._cachedBufferFor(file_path)
         if cached is not None:
             try:
                 markdown_source = cached.decode('utf-8', errors='replace')
@@ -139,8 +149,10 @@ class FileServer:
 
         # If a Sublime view holds an unsaved edit for this path, serve that
         # snapshot instead of the on-disk bytes so live reload reflects
-        # in-progress typing without forcing a save.
-        cached = BufferCache.getInstance().get(full_path)
+        # in-progress typing without forcing a save. Only consulted while
+        # the live-reload feature is on; otherwise stale cache entries from
+        # a prior session would shadow the disk file.
+        cached = self._cachedBufferFor(full_path)
         if cached is not None and is_allowed:
             return self._sendFileContents(conn, full_path, mime_type, override_bytes=cached)
 

--- a/liveserverplus_lib/server.py
+++ b/liveserverplus_lib/server.py
@@ -15,6 +15,7 @@ from .request_handler import RequestHandler
 from .logging import info, error
 from .utils import getFreePort
 from .connection_manager import ConnectionManager
+from .buffer_cache import BufferCache
 
 
 class Server(threading.Thread):
@@ -284,7 +285,11 @@ class Server(threading.Thread):
         self._shutdownFileWatcher()
         self._cleanupConnections()
         self._closeSocket()
-        
+
+        # Drop any in-memory buffer snapshots so a subsequent start (or
+        # external edit while stopped) cannot be shadowed by stale bytes.
+        BufferCache.getInstance().clear()
+
         self.status.update('stopped')
         info("Server shutdown complete")
 


### PR DESCRIPTION
## Summary

Fixes #5. Decouples the live-reload preview from Sublime's save pipeline so on-save hooks (`trim_trailing_white_space_on_save`, `ensure_newline_at_eof_on_save`, format-on-save, prettier, isort, etc.) no longer mutate the user's buffer while they type.

## Root cause

`LiveServerPlusListener.on_modified_async` debounced typing by calling `view.run_command('save')`, conflating "tell the browser to refresh" with "commit this to disk." Every keystroke fired the user's on-save hooks. The reporter's `trim_trailing_white_space_on_save: all` setting was deleting trailing spaces the moment they were typed, but the same code path corrupts buffers for anyone with a save formatter configured.

## Fix

Treat browser-preview state as separate from disk state — the same approach modern dev servers (Vite, webpack-dev-server, Parcel) use:

1. **`liveserverplus_lib/buffer_cache.py`** — new thread-safe singleton holding `{abs_path → bytes}` snapshots of dirty Sublime buffers.
2. **`on_modified_async`** — replaces the forced save with a buffer snapshot into the cache, then broadcasts the reload directly via `manager.onFileChange(path)`. The user's file on disk is never touched.
3. **`FileServer._serveFile` / `_serveMarkdown`** — consult the cache before reading from disk; cached bytes flow through the existing WebSocket-injection path so HTML preview still works.
4. **`on_post_save_async` / `on_close` / `plugin_unloaded`** — evict cache entries so subsequent reads return the on-disk (post-hooks) contents once the user actually saves.

The `wait` setting still controls the reload debounce; its inline doc comment is updated to reflect that it no longer drives an auto-save.

## Test plan

- [ ] Enable `liveReload: true`, set `"trim_trailing_white_space_on_save": "all"` globally, type trailing spaces in a Markdown file — spaces remain in the buffer and are visible in the browser preview without being deleted.
- [ ] Same setup with an HTML file and `format_on_save` enabled (e.g., Prettier) — typing does not trigger reformatting.
- [ ] Type in an HTML file, confirm the browser refreshes and shows the unsaved content; save the file, confirm browser still shows the saved (post-hooks) content.
- [ ] Markdown preview reflects unsaved edits as you type.
- [ ] Close a dirty buffer without saving — browser request after close serves on-disk content (cache evicted on `on_close`).
- [ ] Stop and restart the server while a buffer is dirty — no stale state.

https://claude.ai/code/session_01JUVZV7avHKREMuk2heRjt7